### PR TITLE
Fix cookie retrieval

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -9,7 +9,7 @@ const JWT_SECRET = new TextEncoder().encode(
 
 export async function GET() {
     try {
-        const cookieStore = await cookies()
+        const cookieStore = cookies()
         const token = cookieStore.get('auth-token')?.value
 
         if (!token) {


### PR DESCRIPTION
## Summary
- remove unnecessary await in auth cookie retrieval

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'tailwind-merge', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f854c4af4832192d5d1c2b68718f0