### PR TITLE
Fix middleware allowing static svg

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,6 @@ export const config = {
         /*
          * 匹配除了 _next/static、_next/image、favicon.ico 等静态资源以外的所有路由
          */
-        '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        '/((?!api|_next/static|_next/image|favicon.ico|.*\\.svg).*)',
     ],
 }


### PR DESCRIPTION
## Summary
- exclude svg files from NextAuth middleware so public assets load correctly on Vercel

## Testing
- `npm run build` *(fails: Property 'get' does not exist on type 'Promise<ReadonlyRequestCookies>')*

------
https://chatgpt.com/codex/tasks/task_e_6840d880cb0c8321874e938653801c33