### PR TITLE
Fix cookies call awaiting

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -9,7 +9,7 @@ const JWT_SECRET = new TextEncoder().encode(
 
 export async function GET() {
     try {
-        const cookieStore = cookies()
+        const cookieStore = await cookies()
         const token = cookieStore.get('auth-token')?.value
 
         if (!token) {


### PR DESCRIPTION
## Summary
- await `cookies()` in `/api/auth/me` route to comply with Next.js 15.x

## Testing
- `npm run lint`
- `npm run build` *(fails: @prisma/client did not initialize yet)*
- `npx prisma generate` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6840db38c1148321b7d64969a5175078