### PR TITLE
Fix Tailwind v4 configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,9 +1,14 @@
+/**
+ * PostCSS configuration for Tailwind CSS v4.
+ * The new `@tailwindcss/postcss` plugin replaces the old `tailwindcss` plugin
+ * used in previous versions.
+ */
+import tailwindcss from "@tailwindcss/postcss";
+import autoprefixer from "autoprefixer";
+
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
+  plugins: [tailwindcss, autoprefixer],
 };
 
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,8 @@
 import type { Config } from "tailwindcss";
 
+// Tailwind CSS v4 configuration
+// Ensure that all relevant directories are included in `content`
+
 const config: Config = {
     darkMode: 'class',
     content: [


### PR DESCRIPTION
## Summary
- update PostCSS configuration to use `@tailwindcss/postcss` plugin via ESM
- document Tailwind CSS v4 in the configuration files

## Testing
- `node -e "import('./postcss.config.mjs').then(r => console.log(r.default))"`
- `npm install` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e1614f8988321a23bbe341c1df623